### PR TITLE
Too fast start of xrdp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
-FROM alpine:latest
+FROM alpine:edge
 
-RUN apk add --no-cache xvfb x11vnc fluxbox supervisor xterm bash chromium xrdp
-RUN apk add --no-cache wqy-zenhei novnc websockify firefox -X https://mirrors.aliyun.com/alpine/edge/testing/
+RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories
+RUN apk update
+RUN apk add --no-cache xvfb x11vnc fluxbox supervisor xterm bash chromium firefox xrdp wqy-zenhei novnc websockify
 
 RUN ln -s /usr/share/novnc/vnc_lite.html /usr/share/novnc/index.html
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:edge
+FROM alpine:latest
 
 RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories
 RUN apk update

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -23,7 +23,7 @@ autorestart=false
 startretries = 1
 
 [program:xrdp]
-command=/usr/sbin/xrdp
+command=bash -c 'sleep 5 && /usr/sbin/xrdp --nodaemon'
 autorestart=true
 startretries = 1
 


### PR DESCRIPTION
I was testing this with my Windows 10 & WSL 2 docker environment and  xrdp started and failed.

Some sleep and  --nodaemon flag to it